### PR TITLE
fix send length when message length > 255

### DIFF
--- a/NolFixLib/src/main/java/com/fermich/nolfix/fix/client/NolClient.java
+++ b/NolFixLib/src/main/java/com/fermich/nolfix/fix/client/NolClient.java
@@ -45,9 +45,11 @@ public class NolClient implements NolSender, NolReceiver {
     public void send(String rawMsg) {
         try {
             byte[] fixArray = rawMsg.getBytes();
-            byte[] fixArrayWith0 = Arrays.copyOf(fixArray, fixArray.length + 1);
+            int msgSize = fixArray.length + 1;
+            byte[] sizeArray = String.valueOf(msgSize).getBytes();
+            byte[] fixArrayWith0 = Arrays.copyOf(fixArray, msgSize);
 
-            outStream.write(fixArrayWith0.length);
+            outStream.write(sizeArray);
             outStream.flush();
 
             outStream.write(fixArrayWith0);


### PR DESCRIPTION
When FIXML in request has length > 255 the size was not sent and wrong interpreted by NOL3 (only 32 bytes of FIXML message)
