### PR TITLE
change Px as String

### DIFF
--- a/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/filter/MarketDataIncrementalRefresh.java
+++ b/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/filter/MarketDataIncrementalRefresh.java
@@ -47,7 +47,7 @@ public class MarketDataIncrementalRefresh extends FixmlMessage {
 
         @XStreamAlias("Px")
         @XStreamAsAttribute
-        private Float px; //cena
+        private String px; //cena (can be PKC, PCR)
 
         @XStreamAlias("MDPxLvl")
         @XStreamAsAttribute
@@ -148,11 +148,11 @@ public class MarketDataIncrementalRefresh extends FixmlMessage {
             return this;
         }
 
-        public Float getPx() {
+        public String getPx() {
             return px;
         }
 
-        public MdIncGrp setPx(Float px) {
+        public MdIncGrp setPx(String px) {
             this.px = px;
             return this;
         }

--- a/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/order/ExecutionReport.java
+++ b/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/order/ExecutionReport.java
@@ -71,7 +71,7 @@ public class ExecutionReport extends FixmlMessage {
 
     @XStreamAlias("Px")
     @XStreamAsAttribute
-    private Float px; //cena
+    private String px; //cena
 
     @XStreamAlias("StopPx")
     @XStreamAsAttribute
@@ -394,11 +394,11 @@ public class ExecutionReport extends FixmlMessage {
         return this;
     }
 
-    public Float getPx() {
+    public String getPx() {
         return px;
     }
 
-    public ExecutionReport setPx(Float px) {
+    public ExecutionReport setPx(String px) {
         this.px = px;
         return this;
     }

--- a/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/order/NewOrderSingle.java
+++ b/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/order/NewOrderSingle.java
@@ -58,7 +58,7 @@ public class NewOrderSingle extends FixmlRequest {
 
     @XStreamAlias("Px")
     @XStreamAsAttribute
-    private Float px; //cena
+    private String px; //cena
 
     @XStreamAlias("StopPx")
     @XStreamAsAttribute
@@ -183,11 +183,11 @@ public class NewOrderSingle extends FixmlRequest {
         return this;
     }
 
-    public Float getPx() {
+    public String getPx() {
         return px;
     }
 
-    public NewOrderSingle setPx(Float px) {
+    public NewOrderSingle setPx(String px) {
         this.px = px;
         return this;
     }

--- a/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/order/OrderCancelReplaceRequest.java
+++ b/NolFixLib/src/main/java/com/fermich/nolfix/fix/msg/order/OrderCancelReplaceRequest.java
@@ -68,7 +68,7 @@ public class OrderCancelReplaceRequest extends FixmlRequest {
 
     @XStreamAlias("Px")
     @XStreamAsAttribute
-    private Float px; //cena
+    private String px; //cena
 
     @XStreamAlias("StopPx")
     @XStreamAsAttribute
@@ -228,11 +228,11 @@ public class OrderCancelReplaceRequest extends FixmlRequest {
         return this;
     }
 
-    public Float getPx() {
+    public String getPx() {
         return px;
     }
 
-    public OrderCancelReplaceRequest setPx(Float px) {
+    public OrderCancelReplaceRequest setPx(String px) {
         this.px = px;
         return this;
     }


### PR DESCRIPTION
Px in MarketDataIncrementalRefresh (BID, OFFER) could be "PKC" or "PCR". The same could be in NewOrderSingle, OrderCancelReplaceRequest and ExecutionReport
